### PR TITLE
Improve server performance

### DIFF
--- a/server/flight_intel_patch.py
+++ b/server/flight_intel_patch.py
@@ -193,7 +193,8 @@ class AeroAPIClient:
         self._session: Optional[aiohttp.ClientSession] = None
 
     async def __aenter__(self) -> "AeroAPIClient":
-        self._session = aiohttp.ClientSession(headers=self._headers)
+        connector = aiohttp.TCPConnector(limit_per_host=5)
+        self._session = aiohttp.ClientSession(headers=self._headers, connector=connector)
         return self
 
     async def __aexit__(self, exc_type, exc, tb) -> None:
@@ -367,7 +368,8 @@ class FR24Client:
         self._session: Optional[aiohttp.ClientSession] = None
 
     async def __aenter__(self) -> "FR24Client":
-        self._session = aiohttp.ClientSession(headers=self._headers)
+        connector = aiohttp.TCPConnector(limit_per_host=5)
+        self._session = aiohttp.ClientSession(headers=self._headers, connector=connector)
         return self
 
     async def __aexit__(self, exc_type, exc, tb) -> None:


### PR DESCRIPTION
## Summary
- enable GZip compression and scale thread pool with CPU cores
- tune AeroAPI and FR24 clients to reuse HTTP connections
- strip spurious prompt text at end of main

## Testing
- `python -m py_compile server/*.py`
- `python main.py` (started and served)


------
https://chatgpt.com/codex/tasks/task_e_6889602b7c308332bab63fce2bb1ef50