### PR TITLE
Optimize validation API sessions

### DIFF
--- a/server/flight_intel_patch.py
+++ b/server/flight_intel_patch.py
@@ -448,6 +448,28 @@ class FlightValidator:
         if not (FIREHOSE_USERNAME and FIREHOSE_PASSWORD):
             logger.warning("Firehose credentials not configured – Firehose enrichment disabled")
 
+        # Reusable API clients for batch validation
+        self._aero_client: Optional[AeroAPIClient] = None
+        self._fr24_client: Optional[FR24Client] = None
+
+    async def open_clients(self) -> None:
+        """Initialize API clients for reuse across many flights."""
+        if self._has_aeroapi and not self._aero_client:
+            self._aero_client = AeroAPIClient(FLIGHTAWARE_API_KEY)
+            await self._aero_client.__aenter__()
+        if self._has_fr24 and not self._fr24_client:
+            self._fr24_client = FR24Client(FLIGHTRADAR24_API_KEY)
+            await self._fr24_client.__aenter__()
+
+    async def close_clients(self) -> None:
+        """Close any opened API clients."""
+        if self._aero_client:
+            await self._aero_client.__aexit__(None, None, None)
+            self._aero_client = None
+        if self._fr24_client:
+            await self._fr24_client.__aexit__(None, None, None)
+            self._fr24_client = None
+
     async def validate_flight(self, flight: Dict) -> ValidationResult:
         """Enhanced validation that actively fills missing fields."""
         flight_no = flight.get("flight_no")
@@ -492,16 +514,20 @@ class FlightValidator:
 
         api_results: Dict[str, Dict] = {}
 
-        # Each lookup gets its own client/session
+        # Use shared clients when available to avoid reconnect overhead
         async def aero_task():
             if not self._has_aeroapi:
                 return None
+            if self._aero_client:
+                return "aeroapi", await self._aero_client.search_flight(flight_no, flight_date)
             async with AeroAPIClient(FLIGHTAWARE_API_KEY) as client:
                 return "aeroapi", await client.search_flight(flight_no, flight_date)
 
         async def fr24_task():
             if not self._has_fr24:
                 return None
+            if self._fr24_client:
+                return "fr24", await self._fr24_client.search_flight(flight_no, flight_date)
             async with FR24Client(FLIGHTRADAR24_API_KEY) as client:
                 return "fr24", await client.search_flight(flight_no, flight_date)
 
@@ -801,8 +827,12 @@ class FlightValidator:
         """Validate a list of flight dicts concurrently."""
         start = time.time()
 
-        tasks = [self.validate_flight(f) for f in flights]
-        validations = await asyncio.gather(*tasks, return_exceptions=True)
+        await self.open_clients()
+        try:
+            tasks = [self.validate_flight(f) for f in flights]
+            validations = await asyncio.gather(*tasks, return_exceptions=True)
+        finally:
+            await self.close_clients()
 
         enriched_flights: List[EnrichedFlight] = []
         warnings: List[str] = []


### PR DESCRIPTION
## Summary
- reuse API clients across validation tasks
- skip reconnection overhead when validating many flights

## Testing
- `python -m py_compile server/*.py`

------
https://chatgpt.com/codex/tasks/task_e_6889602b7c308332bab63fce2bb1ef50