### PR TITLE
Improve API server performance

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,16 @@
 # FIDCODEPYTHON
+
+Simple demo for the Flight‑Intel extractor. To use:
+
+1. Install dependencies:
+   ```bash
+   pip install -r server/requirements.txt
+   ```
+
+2. Start the API server:
+   ```bash
+   cd server
+   python main.py
+   ```
+
+3. Open `client/index.html` in your browser and upload a roster image or PDF.


### PR DESCRIPTION
## Summary
- allow thread pool size to be tuned with `MAX_WORKERS`
- add simple in-memory cache to O4-Mini extractor
- update README with run instructions

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6889602b7c308332bab63fce2bb1ef50